### PR TITLE
redhat: switch to ansible_distribution_major_version because previous…

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,4 +1,1 @@
-os_version: "{{ ansible_lsb.release if ansible_lsb is defined else ansible_distribution_version }}"
-os_version_major: "{{ os_version | regex_replace('^([0-9]+)[^0-9]*.*', '\\\\1') }}"
-
-docker_yum_repo: "https://yum.dockerproject.org/repo/main/{{ ansible_distribution | lower }}/{{ os_version_major }}"
+docker_yum_repo: "https://yum.dockerproject.org/repo/main/{{ ansible_distribution | lower }}/{{ ansible_distribution_major_version }}"


### PR DESCRIPTION
… regex is broken in ansible 2.0.0.2
